### PR TITLE
Fix .env path handling

### DIFF
--- a/Documentation/CV_Processor.md
+++ b/Documentation/CV_Processor.md
@@ -5,7 +5,7 @@
 **Key Files**:
 - `process_cv/cv_processor.py`: Main script for processing and summarizing CVs
 - `process_cv/cv_to_html_converter.py`: Script for converting CVs to HTML format
-- `process_cv/.env`: Environment variables (OpenAI API key). The script specifically loads it from `c:/Codes/JobsearchAI/process_cv/.env`.
+- `process_cv/.env`: Environment variables (OpenAI API key). The script loads this file from the same directory as the CV processor scripts.
 
 **Technologies**:
 - PyMuPDF (fitz) for PDF text and structure extraction

--- a/process_cv/cv_processor.py
+++ b/process_cv/cv_processor.py
@@ -21,7 +21,8 @@ def extract_cv_text(file_path):
     else:
         raise ValueError("Unsupported file type. Only PDF allowed.")
 
-env_path = Path("c:/Codes/JobsearchAI/process_cv/.env")
+# Load environment variables from the .env file located next to this script
+env_path = Path(__file__).resolve().parent / ".env"
 load_dotenv(dotenv_path=env_path)
 
 # Initialize the OpenAI client

--- a/process_cv/cv_to_html_converter.py
+++ b/process_cv/cv_to_html_converter.py
@@ -18,7 +18,8 @@ logging.basicConfig(
 logger = logging.getLogger("cv_to_html_converter")
 
 # Load environment variables
-env_path = Path("c:/Codes/JobsearchAI/process_cv/.env")
+# Load environment variables from the .env file located next to this script
+env_path = Path(__file__).resolve().parent / ".env"
 load_dotenv(dotenv_path=env_path)
 
 # Initialize the OpenAI client


### PR DESCRIPTION
## Summary
- resolve .env path relative to script in `cv_processor.py`
- same fix for `cv_to_html_converter.py`
- update docs about env file location

## Testing
- `python -m py_compile $(find . -name '*.py')`